### PR TITLE
:art: Add DjangoCon EU to index events

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
         "Django",
         "Django Chat",
         "Django News",
+        "DjangoCon €U",
         "Djangonaut Space enters orbit",
         "Executive Director",
         "Flask",


### PR DESCRIPTION
It's not "DjangoCon EU".

I know it. You know it. We all know it, and yet here we are. 

![Screenshot_2025-05-02-12-35-03-48_e307a3f9df9f380ebaf106e1dc980bb6](https://github.com/user-attachments/assets/87acd35b-4359-446f-a729-6e2d683bebe8)
